### PR TITLE
arreglando el renderizado de las KitCard

### DIFF
--- a/src/Component/overview/Overview.jsx
+++ b/src/Component/overview/Overview.jsx
@@ -26,15 +26,13 @@ const Overview = () => {
           <TabPanel>
             <Grid numItemsMd={2} numItemsLg={3} className="gap-6 mt-6">
               {date.map(({ id, metric, target, progress, deltaType }) => (
-                <>
-                  <KpiCard
-                    key={id}
-                    metric={metric}
-                    target={target}
-                    progress={progress}
-                    deltaType={deltaType}
-                  />
-                </>
+                <KpiCard
+                  key={id}
+                  metric={metric}
+                  target={target}
+                  progress={progress}
+                  deltaType={deltaType}
+                />
               ))}
             </Grid>
             <div className="mt-6">


### PR DESCRIPTION
Se arreglo:
> renderizado de la barra de progreso
> renderizado de la etiqueta del porcentaje. Agregando los templatesStrings en el renderizado y no en lo que retorna la funcion.